### PR TITLE
🔒 security: Fix hardcoded credentials in build.gradle.kts

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -41,19 +41,19 @@ android {
 
     signingConfigs {
         create("release") {
-            val alias = System.getenv("ANDROID_KEY_ALIAS") ?: keystoreProperties.getProperty("keyAlias") ?: "nafs_ai_key"
+            val alias = System.getenv("ANDROID_KEY_ALIAS") ?: keystoreProperties.getProperty("keyAlias")
             val keyPass = System.getenv("ANDROID_KEY_PASSWORD") ?: keystoreProperties.getProperty("keyPassword")
             val storePass = System.getenv("ANDROID_KEYSTORE_PASSWORD") ?: keystoreProperties.getProperty("storePassword")
             val storeFilePath = keystoreProperties.getProperty("storeFile") ?: "keystore.jks"
 
-            // Ensure we have all required values
-            if (keyPass != null && storePass != null) {
+            // Ensure we have all required values including alias
+            if (alias != null && keyPass != null && storePass != null) {
                 keyAlias = alias
                 keyPassword = keyPass
                 storePassword = storePass
                 storeFile = file(storeFilePath)
             } else {
-                throw GradleException("Missing signing configuration. Please set environment variables or create key.properties file with keyPassword and storePassword.")
+                throw GradleException("Missing signing configuration. Please set environment variables or create key.properties file with keyAlias, keyPassword and storePassword.")
             }
         }
     }


### PR DESCRIPTION
## 🔒 Security Fix: Remove Hardcoded Credentials

This PR addresses the security warning in `android/app/build.gradle.kts` caused by hardcoded credentials.

### ⚠️ **Security Issue Fixed:**

**Before:**
```kotlin
val alias = System.getenv("ANDROID_KEY_ALIAS") ?: keystoreProperties.getProperty("keyAlias") ?: "nafs_ai_key"
```

**After:**
```kotlin
val alias = System.getenv("ANDROID_KEY_ALIAS") ?: keystoreProperties.getProperty("keyAlias")
```

### ✅ **Changes Made:**

1. **Removed hardcoded key alias** `"nafs_ai_key"` fallback
2. **Enhanced validation** to require `keyAlias` from environment variables or `key.properties`
3. **Updated error message** to include `keyAlias` requirement
4. **Improved security** by eliminating hardcoded credentials

### 🛡️ **Security Impact:**

- **Eliminates** hardcoded credential security warning
- **Requires** all signing credentials to be provided securely
- **Prevents** accidental use of default/generic key aliases
- **Enforces** proper credential management practices

### 📋 **Deployment Notes:**

After merging, ensure your deployment environment provides:
- `ANDROID_KEY_ALIAS` environment variable, OR
- `keyAlias` property in `android/key.properties` file

**This is a clean, focused security fix with no merge conflicts.**

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author